### PR TITLE
Fix for items which are not in any folder

### DIFF
--- a/rofi_rbw/rofi_rbw.py
+++ b/rofi_rbw/rofi_rbw.py
@@ -49,17 +49,20 @@ def main() -> None:
 
 
 def get_data(name: str, folder: str) -> Data:
+    command = ['rbw', 'get', '--full', '--folder', folder, name]
+    if folder == "":
+        command = ['rbw', 'get', '--full', name]
     result = run(
-        ['rbw', 'get', '--full', '--folder', folder, name],
+        command,
         capture_output=True,
         encoding='utf-8'
     ).stdout.split('\n')
 
     password = result[0].strip()
-    if len(result[1]) == 0:
-        username = ""
-    else:
-        username = result[1].split(':')[1].strip()
+    username = ""
+    for resultline in result:
+        if resultline.startswith('Username:'):
+            username = resultline.replace('Username: ', '')
 
     return Data(username, password)
 


### PR DESCRIPTION
`rbw` doesn't seem to like a empty folder option, so this PR removes that when an item is not in any folder. I also replaced the Username extraction, as the `if len(result[1]) == 0:` line crashed for me.