### PR TITLE
Fix unable to get entries which are not in a folder

### DIFF
--- a/rofi_rbw/rofi_rbw.py
+++ b/rofi_rbw/rofi_rbw.py
@@ -49,8 +49,13 @@ def main() -> None:
 
 
 def get_data(name: str, folder: str) -> Data:
+
+    arguments = ['rbw', 'get', '--full', name]
+    if len(folder) > 0:
+        arguments += ['--folder', folder]
+
     result = run(
-        ['rbw', 'get', '--full', '--folder', folder, name],
+        arguments,
         capture_output=True,
         encoding='utf-8'
     ).stdout.split('\n')


### PR DESCRIPTION
I was unable to get BitWarden entries which are not in any folder because get_data() always adds the --folder argument, even if no folder was given.