### PR TITLE
Add check for empty strings (i.e. when nothing is selected)

### DIFF
--- a/rofi_rbw/rofi_rbw.py
+++ b/rofi_rbw/rofi_rbw.py
@@ -34,6 +34,9 @@ def main() -> None:
         capture_output=True
     )
 
+    if not rofi.stdout:
+        return
+
     (selected_folder, selected_entry) = rofi.stdout.rsplit('/', 1)
 
     data = get_data(selected_entry.strip(), selected_folder.strip())


### PR DESCRIPTION
Also kinda what the title says, when pressing the ESC button rofi results in no output, which in turn crashes the the `rofi.stdout.rsplit('/', 1)`. Hence I added a small check to make sure that the string is not empty.