### PR TITLE
Add optional OTP code generation/handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 Based on the alternative [Bitwarden](https://bitwarden.com/) CLI [rbw](https://git.tozt.net/rbw) and inspired by [rofi-pass](https://github.com/carnager/rofi-pass), `rbw-rofi` is a simplistic password typer/copier using [rofi](https://github.com/davatorium/rofi).
 
 ## Features
-- Type the selected password with `Enter` or `Alt+3`
+- Type the selected password with `Enter` or `Alt+3` (and copy TOTP to clipboard)
 - Type the selected username with `Alt+2`
-- Autotype username and password (with a `tab` character in between) with `Alt+1`
+- Autotype username and password (with a `tab` character in between) with `Alt+1` (and copy TOTP to clipboard)
 - Copy the username to your clipboard with `Alt+u`
 - Copy the password to your clipboard with `Alt+p`
+- Copy the totp to your clipboard with `Alt+t`
 
 ## Configuration
 You can configure `rofi-rbw` either with cli arguments or with a config file called `$XDG_CONFIG_HOME/rofi-rbw.rc`. In the file, use the long option names without double dashes.

--- a/src/rofi_rbw/credentials.py
+++ b/src/rofi_rbw/credentials.py
@@ -4,6 +4,7 @@ class Credentials:
     def __init__(self, data: str) -> None:
         # Set default values
         self.username = ""
+        self.totp = ""
 
         # Parse rbw output
         self.password, *rest = data.split('\n')
@@ -11,3 +12,9 @@ class Credentials:
             key, value = line.rsplit(": ", 1)
             if key == "Username":
                 self.username = value
+            elif key == "TOTP Secret":
+                try:
+                    import pyotp
+                    self.totp = pyotp.parse_uri(value).now()
+                except ModuleNotFoundError:
+                    pass

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -32,6 +32,7 @@ class RofiRbw(object):
         TYPE_BOTH = 'autotype'
         COPY_USERNAME = 'copy-username'
         COPY_PASSWORD = 'copy-password'
+        COPY_TOTP = 'copy-totp'
 
     def __init__(self) -> None:
         self.args = self.parse_arguments()
@@ -147,6 +148,8 @@ class RofiRbw(object):
             self.args.action = self.Action.COPY_PASSWORD
         elif return_code == 21:
             self.args.action = self.Action.COPY_USERNAME
+        elif return_code == 22:
+            self.args_action = self.Action.COPY_TOTP
 
     def execute_action(self, cred: Credentials) -> None:
         if self.args.action == self.Action.TYPE_PASSWORD:
@@ -163,6 +166,8 @@ class RofiRbw(object):
             self.clipboarder.copy_to_clipboard(cred.password)
         elif self.args.action == self.Action.COPY_USERNAME:
             self.clipboarder.copy_to_clipboard(cred.username)
+        elif self.args.action == self.Action.COPY_TOTP:
+            self.clipboarder.copy_to_clipboard(cred.totp)
 
     def get_credentials(self, name: str, folder: str) -> Credentials:
         command = ['rbw', 'get', '--full', name]

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -151,10 +151,14 @@ class RofiRbw(object):
     def execute_action(self, cred: Credentials) -> None:
         if self.args.action == self.Action.TYPE_PASSWORD:
             self.typer.type_characters(cred.password, self.active_window)
+            if cred.totp != "":
+                self.clipboarder.copy_to_clipboard(cred.totp)
         elif self.args.action == self.Action.TYPE_USERNAME:
             self.typer.type_characters(cred.username, self.active_window)
         elif self.args.action == self.Action.TYPE_BOTH:
             self.typer.type_characters(f"{cred.username}\t{cred.password}", self.active_window)
+            if cred.totp != "":
+                self.clipboarder.copy_to_clipboard(cred.totp)
         elif self.args.action == self.Action.COPY_PASSWORD:
             self.clipboarder.copy_to_clipboard(cred.password)
         elif self.args.action == self.Action.COPY_USERNAME:

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -49,13 +49,15 @@ class Rofi(Selector):
             'Alt+p',
             '-kb-custom-12',
             'Alt+u',
+            '-kb-custom-13',
+            'Alt+t',
             *additional_args
         ]
 
         if show_help_message:
             parameters.extend([
                 '-mesg',
-                '<b>Alt+1</b>: Autotype username and password | <b>Alt+2</b> Type username | <b>Alt+u</b> Copy username | <b>Alt+p</b> Copy password'
+                '<b>Alt+1</b>: Autotype username and password | <b>Alt+2</b> Type username | <b>Alt+u</b> Copy username | <b>Alt+p</b> Copy password | <b>Alt+t</b> Copy totp'
             ])
 
         rofi = run(


### PR DESCRIPTION
Hey there! 
Thank you so much for the great update to version 2.0! Also with the new AUR package life becomes so much easier.

Now for this PR, I often need a TOTP code for 2FA, for which I wrote a small wrapper cli, but I figured, why not add it to rofi-rbw?

Features/considerations/design decisions:
- Added Alt+t action to obtain the totp code for uniformity with Alt+p and Alt+u
- Added automatic copying when auto-typing the password or username&password, similar to how the Bitwarden browser extension does it.
- Opted for PyOTP which seems mature and supports multiple OTP methods, but most of all allows for automated URI parsing.
- Added PyOTP as an optional dependency, that way nothing breaks and people can still use it without.
- Did not add a abstracted "totp" class (or something similair), to reduce effort to maintain multiple libs, but might be added if wanted.
- Did not update AUR package with optional `python-pyotp` dependency, as it seems it is not maintained in this repo.
- Eventhough PyOTP supports multiple methods, rbw calls it "TOTP Secret", thus I opted for naming everything TOTP as well and using `Alt+t` rather than `Alt+o`. Maybe this should be changed to just OTP, thoughts?

Links:
- [PyOTP main site](https://pyauth.github.io/pyotp/)
- [PyOTP Github](https://github.com/pyauth/pyotp)

Hope you like it, if you want anything changed let me know! (This time I'll respond faster than last, not as stressed as I was back then :D)