### PR TITLE
Add --fields option  to pass onto `rbw list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can configure `rofi-rbw` either with cli arguments or with a config file cal
 | --- | --- | --- | --- |
 | `--action` | `-a` | `type-password` (default), `type-username`, `autotype`, `copy-username`, `copy-password` | Chose what `rofi-rbw` should do. |
 | `--prompt` | `-r` | any string | Define the prompt text for `rofimoji`. |
+| `--fields` | `-f` | any string | What to pass for `--field` when running `rbw list`. |
 | `--show-help` | | `true` (default), `false` | Show a help message with the available shortcuts. |
 | `--rofi-args` | | | Define arguments that will be passed through to `rofi`.<br/>Please note that you need to specify it as `--rofi-args="<rofi-args>"` or `--rofi-args " <rofi-args>"` because of a [bug in argparse](https://bugs.python.org/issue9334) |
 | `--selector` | | `rofi`, `wofi` | Show the selection dialog with this application. |

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -63,7 +63,15 @@ class RofiRbw(object):
             action='store',
             default='Select entry',
             help='Set rofi-rbw\'s  prompt'
-        )
+        ),
+        parser.add_argument(
+            '--fields',
+            '-f',
+            dest='fields',
+            action='store',
+            default='folder,name',
+            help='What to pass to pass for --field when running `rbw list`'
+        ),
         parser.add_argument(
             '--rofi-args',
             dest='rofi_args',
@@ -115,7 +123,7 @@ class RofiRbw(object):
 
     def main(self) -> None:
         entries = run(
-            ['rbw', 'ls', '--fields', 'folder,name'],
+            ['rbw', 'ls', '--fields', self.args.fields],
             encoding='utf-8',
             capture_output=True
         ).stdout.strip().split('\n')


### PR DESCRIPTION
First off, thanks for both `rbw` and `rofi-rbw`. I was looking to integrate Bitwarden with Rofi, but the official NodeJS client was much slower than I wanted. 

This PR's title is self-explanatory I think.