### PR TITLE
Remove entry stripping

### DIFF
--- a/src/rofi_rbw/entry.py
+++ b/src/rofi_rbw/entry.py
@@ -8,7 +8,7 @@ class Entry:
         self.folder = ''
         self.username = ''
 
-        fields = data.strip().split('\t')
+        fields = data.split('\t')
         self.name = fields[1]
         self.folder = fields[0]
         self.length = len(self.name) + len(self.folder) + 1


### PR DESCRIPTION
After calling `rbw ls --fields folder,name,user` the output data is passed, line-by-line, into the entry constructor. Since it's passed line-by-line any newline characters are automatically stripped. By stripping the entry once more the leading `\t` character is stripped if the entry does not have a parent folder, resulting in an index exception on `self.name = field[1]`. Simply removing the `strip` call fixes all of this.

PS: I have the AUR version installed and don't seem to experience any index errors here, but I do have them when I clone the repo and run it that way, no idea why.