### PR TITLE
[Bug fix] Change no password logic to allow for notes

### DIFF
--- a/src/rofi_rbw/credentials.py
+++ b/src/rofi_rbw/credentials.py
@@ -9,12 +9,13 @@ class Credentials:
         self.totp = ''
         self.further = {}
 
-        self.password, *rest = data.strip().split('\n')
-        if len(self.password.split(": ", 1)) == 2:
-            # Password contains ': ' and thus is probably a key-value pair
+        line, *rest = data.strip().split('\n')
+        if len(line.split(": ", 1)) == 2:
+            # First line contains ': ' and thus is probably a key-value pair
             # This means there is no password for this entry
-            rest = [self.password] + rest
-            self.password = ''
+            rest = [line] + rest
+        else:
+            self.password = line
 
         for line in rest:
             try:


### PR DESCRIPTION
In commit [Handle entries without password](https://github.com/fdw/rofi-rbw/commit/99103ca61a8aea2d1a558fe0c7763cc52f089c80#diff-4a186327e731452e745ca91b6ef0ada5af0862462f353418b9c8897dd374ecf6L10) the handling of lines without key (e.g. not `username: tosti007`) has changed. It is now assumed that lines without key are the password and each time such line is found it is set as the password field.
However rbw prints full entries as follows:
```
[password]
Username: [username]
TOTP Secret: [secret]
URI: [uri]
[notes]
```

where fields between `[]` are replaced with actual values and URI lines may be repeated n times (it might be possible that I am missing some fields but this is the most extensive case in my personal bw). 

`[notes]` is not prepended with any key and thus the last non-empty line of the notes section is set as password (and thus the entry has an incorrect password).

The solution that I pr here is to handle only the first line differently and to discard all the following no-key entries. I opted to go for a discard solution as I did not have the time to solve multi-line notes properly showing in the menu action. Also a small benefit from this way is that it omits a try-catch block.
