### PR TITLE
Allow for multiple URIs in menu action

### DIFF
--- a/src/rofi_rbw/credentials.py
+++ b/src/rofi_rbw/credentials.py
@@ -7,6 +7,7 @@ class Credentials:
         self.username = ''
         self.password = ''
         self.totp = ''
+        self.uris = []
         self.further = {}
 
         line, *rest = data.strip().split('\n')
@@ -22,6 +23,8 @@ class Credentials:
                 key, value = line.split(": ", 1)
                 if key == "Username":
                     self.username = value
+                elif key == "URI":
+                    self.uris.append(value)
                 elif key == "TOTP Secret":
                     try:
                         import pyotp
@@ -41,6 +44,8 @@ class Credentials:
             return self.password
         elif item.lower() == 'totp':
             return self.totp
+        elif item.lower() == 'uris':
+            return self.uris
         else:
             try:
                 return self.further[item]

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -199,11 +199,13 @@ class RofiRbw(object):
             entries.append(f'Password: {cred.password[0]}{"*" * (len(cred.password) -1)}')
         if cred.totp:
             entries.append(f'TOTP: {cred.totp}')
+        if len(cred.uris) == 1:
+            entries.append(f'URI: {cred.uris[0]}')
+        else:
+            for (key, value) in enumerate(cred.uris):
+                entries.append(f'URI {key + 1}: {value}')
         for (key, value) in cred.further.items():
-            if key == 'URI':
-                entries.append(f'{key}: {value}')
-            else:
-                entries.append(f'{key}: {value[0]}{"*" * (len(value) -1)}')
+            entries.append(f'{key}: {value[0]}{"*" * (len(value) -1)}')
 
         (returncode, entry) = self.selector.show_selection(
             "\n".join(entries),
@@ -216,7 +218,16 @@ class RofiRbw(object):
             self.main()
         self.choose_action_from_return_code(returncode)
 
-        self.typer.type_characters(cred[entry.split(': ')[0]], self.active_window)
+        key, value = entry.split(': ', 1)
+
+        if key == 'URI':
+            value = cred.uris[0]
+        elif key.startswith('URI'):
+            value = cred.uris[int(key[4:]) - 1]
+        else:
+            value = cred[key]
+
+        self.typer.type_characters(value, self.active_window)
 
 
 def main():


### PR DESCRIPTION
When using the menu action a value for `URI` is shown, however this value is always the last URI as each time a new URI is read it overwrites the previous value. Hence this PR which adds an incrementing number to each URI key.

The other option would be to add a `uri` array field to `Credentials`, but this would require more difficult logic in `rofi_rbw.py`. Hence I opted for adding them to 'further' and only change `rofi_rbw.py` only a little.