### PR TITLE
Remove redundant choose_action call

### DIFF
--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -216,7 +216,6 @@ class RofiRbw(object):
 
         if returncode == 1:
             self.main()
-        self.choose_action_from_return_code(returncode)
 
         key, value = entry.split(': ', 1)
 


### PR DESCRIPTION
The `choose_action` call in `autotype_menu` does not do anything as the action is unused, it only overwrites the `self.action` value which might be weird behavior at some later stage.