### PR TITLE
Let show_selection accept a list of entries

### DIFF
--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -127,7 +127,7 @@ class RofiRbw(object):
         entries = sorted(map(lambda it: it.formatted_string(maxwidth), parsed_entries))
 
         (returncode, entry) = self.selector.show_selection(
-            '\n'.join(entries),
+            entries,
             self.args.prompt,
             self.args.show_help,
             self.args.rofi_args
@@ -208,7 +208,7 @@ class RofiRbw(object):
             entries.append(f'{key}: {value[0]}{"*" * (len(value) -1)}')
 
         (returncode, entry) = self.selector.show_selection(
-            "\n".join(entries),
+            entries,
             prompt='Autotype field',
             show_help_message=False,
             additional_args=[]

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -28,7 +28,7 @@ class Selector:
 
     def show_selection(
         self,
-        entries: str,
+        entries: List[str],
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
@@ -48,7 +48,7 @@ class Rofi(Selector):
 
     def show_selection(
         self,
-        entries: str,
+        entries: List[str],
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
@@ -80,7 +80,7 @@ class Rofi(Selector):
 
         rofi = run(
             parameters,
-            input=entries,
+            input='\n'.join(entries),
             capture_output=True,
             encoding='utf-8'
         )
@@ -98,7 +98,7 @@ class Wofi(Selector):
 
     def show_selection(
         self,
-        entries: str,
+        entries: List[str],
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
@@ -113,7 +113,7 @@ class Wofi(Selector):
 
         wofi = run(
             parameters,
-            input=entries,
+            input='\n'.join(entries),
             capture_output=True,
             encoding='utf-8'
         )


### PR DESCRIPTION
Minor refactor to `show_selection`, as a selection is always a list of items I thought it would make more sense to move the newline-join into that function. Who knows maybe there will be a rofi python library that only accepts a lists of items.