### PR TITLE
Refactor return calls

### DIFF
--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -3,7 +3,6 @@
 import argparse
 import enum
 import shlex
-import sys
 from collections import namedtuple
 from subprocess import run
 
@@ -133,7 +132,7 @@ class RofiRbw(object):
             self.args.rofi_args
         )
         if returncode == 1:
-            sys.exit()
+            return
 
         (selected_folder, selected_entry) = entry.split('</b>')[0].replace('<b>', '').strip().rsplit('/', 1)
 
@@ -215,6 +214,7 @@ class RofiRbw(object):
 
         if returncode == 1:
             self.main()
+            return
 
         key, value = entry.split(': ', 1)
 

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -132,7 +132,8 @@ class RofiRbw(object):
             self.args.show_help,
             self.args.rofi_args
         )
-        self.choose_action_from_return_code(returncode)
+        if returncode == 1:
+            sys.exit()
 
         (selected_folder, selected_entry) = entry.split('</b>')[0].replace('<b>', '').strip().rsplit('/', 1)
 
@@ -141,9 +142,7 @@ class RofiRbw(object):
         self.execute_action(data)
 
     def choose_action_from_return_code(self, return_code: int) -> None:
-        if return_code == 1:
-            sys.exit()
-        elif return_code == 12:
+        if return_code == 12:
             self.args.action = self.Action.TYPE_PASSWORD
         elif return_code == 11:
             self.args.action = self.Action.TYPE_USERNAME


### PR DESCRIPTION
I think it would be a bit clearer if the `return_code == 1` case would be handled by the rofi-calling function and if `choose_action` doesn't exit the entire program by itself. Hence I moved it out of `choose_action` and into `main`.

Now that main does the check for the return code, it can also simply return instead of closing the entire program, this way any calling code can still do some stuff afterwards. This thus also requires a return in `show_menu`, as it would try to auto-type something otherwise.