### PR TITLE
Add username to rbw get call

### DIFF
--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -136,7 +136,7 @@ class RofiRbw(object):
 
         selected_entry = Entry.parse_formatted_string(selected_string)
 
-        data = self.get_credentials(selected_entry.name, selected_entry.folder)
+        data = self.get_credentials(selected_entry.name, selected_entry.folder, selected_entry.username)
 
         self.execute_action(data)
 
@@ -176,8 +176,8 @@ class RofiRbw(object):
         elif self.args.action == self.Action.AUTOTYPE_MENU:
             self.show_autotype_menu(cred)
 
-    def get_credentials(self, name: str, folder: str) -> Credentials:
-        command = ['rbw', 'get', '--full', name]
+    def get_credentials(self, name: str, folder: str, username: str) -> Credentials:
+        command = ['rbw', 'get', '--full', name, username]
         if folder != "":
             command.extend(["--folder", folder])
 


### PR DESCRIPTION
Sorry for all the spam!

In `rbw` it's possible to specify which username the entry should have. Passing an empty string to `rbw get [name] [user]` as `[user]` field is the same as passing no argument. Hence I think it might be nice to pass the username along (since we know it anyway) so we omit possible wrong selections due to the naming.