### PR TITLE
Add initial alternative totp method

### DIFF
--- a/src/rofi_rbw/credentials.py
+++ b/src/rofi_rbw/credentials.py
@@ -1,9 +1,10 @@
 from typing import Union
+from subprocess import run
 
 
 class Credentials:
 
-    def __init__(self, data: str) -> None:
+    def __init__(self, name: str, folder: str, data: str) -> None:
         self.username = ''
         self.password = ''
         self.totp = ''
@@ -26,11 +27,15 @@ class Credentials:
                 elif key == "URI":
                     self.uris.append(value)
                 elif key == "TOTP Secret":
-                    try:
-                        import pyotp
-                        self.totp = pyotp.parse_uri(value).now()
-                    except ModuleNotFoundError:
-                        pass
+                    command = ['rbw', 'code', name]
+                    if folder != "":
+                        command.extend(["--folder", folder])
+
+                    self.totp = run(
+                        command,
+                        capture_output=True,
+                        encoding='utf-8'
+                    ).stdout.strip()
                 else:
                     self.further[key] = value
             except ValueError:

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -187,7 +187,7 @@ class RofiRbw(object):
             encoding='utf-8'
         ).stdout
 
-        return Credentials(result)
+        return Credentials(name, folder, result)
 
     def show_autotype_menu(self, cred: Credentials):
         entries = []


### PR DESCRIPTION
This is the PR for #33. 

I had to pass along the name and folder as well, since it's needed for the `code` call.

When using the `--action=menu` option it's a a tiny bit (but noticeable in comparison) slower before the menu is shown, do you think that's bad/unwanted/too noticeable?