### PR TITLE
Fix empty credential object when username is missing

### DIFF
--- a/src/rofi_rbw/credentials.py
+++ b/src/rofi_rbw/credentials.py
@@ -16,7 +16,10 @@ class Credentials:
         self.__load_from_rbw(name, username, folder)
 
     def __load_from_rbw(self, name: str, username: str, folder: Optional[str]):
-        command = ['rbw', 'get', '--full', name, username]
+        command = ['rbw', 'get', '--full', name]
+        if username:
+            command.append(username)
+
         if folder != "":
             command.extend(["--folder", folder])
 


### PR DESCRIPTION
Hi, it's me again :) I noticed while using rofi-rbw that selecting an entry without a username (like for ssh-keys or card-type entries) results in rofi-rbw bugging out and not copying anything to the clipboard. Digging into the code I tracked this down to a `None` being passed to rbw during the request for the credentials which somehow returns a completely empty credential object. 

This PR provides a simple fix for the problem and allows using for both entries without usernames as well as other entry types from rofi-rbw. 