### PR TITLE
use time.sleep instead of ydotool sleep

### DIFF
--- a/src/rofi_rbw/typer.py
+++ b/src/rofi_rbw/typer.py
@@ -1,4 +1,5 @@
 from subprocess import run
+import time
 
 try:
     from rofi_rbw.abstractionhelper import is_wayland, is_installed
@@ -91,11 +92,9 @@ class YDotoolTyper(Typer):
         return "not possible with ydotool"
 
     def type_characters(self, characters: str, active_window: str) -> None:
+        time.sleep(0.05)
         run([
             'ydotool',
-            'sleep',
-            '50',
-            ',',
             'type',
             characters
         ])


### PR DESCRIPTION
ydotool backend is broken under ydotool v1.0.0 update
> Command chaining and sleep are removed because this should be your shell's job
