### PR TITLE
WIP: Changing help texts

### DIFF
--- a/src/rofi_rbw/models.py
+++ b/src/rofi_rbw/models.py
@@ -48,7 +48,3 @@ class CANCEL:
     def __eq__(self, other):
         return isinstance(other, CANCEL)
 
-
-class DEFAULT:
-    def __eq__(self, other):
-        return isinstance(other, DEFAULT)

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -139,10 +139,12 @@ class RofiRbw(object):
         credential = self.get_credentials(selected_entry.name, selected_entry.folder, selected_entry.username)
 
         if Targets.MENU in self.args.targets:
-            targets, action = self.show_target_menu(credential, self.args.show_help,)
-            self.args.targets = targets
-            if action != DEFAULT():
-                self.args.action = action
+            selected_targets, selected_action = self.show_target_menu(credential)
+            if selected_action == CANCEL():
+                self.main()
+                return
+            self.args.targets = selected_targets
+            self.args.action = selected_action
 
         self.execute_action(credential)
 
@@ -165,9 +167,8 @@ class RofiRbw(object):
 
     def show_target_menu(
         self,
-        cred: Credentials,
-        show_help_message: bool
-    ) -> Tuple[List[Target], Union[Action, DEFAULT]]:
+        cred: Credentials
+    ) -> Tuple[List[Target], Action]:
         entries = []
         if cred.username:
             entries.append(f'Username: {cred.username}')
@@ -183,13 +184,7 @@ class RofiRbw(object):
         for (key, value) in cred.further.items():
             entries.append(f'{key}: {value[0]}{"*" * (len(value) - 1)}')
 
-        targets, action = self.selector.select_target(entries, show_help_message, additional_args=self.args.selector_args)
-
-        if targets == CANCEL():
-            self.main()
-            return
-
-        return targets, action
+        return self.selector.select_target(entries, self.args.action, self.args.show_help, additional_args=self.args.selector_args)
 
     def execute_action(self, cred: Credentials) -> None:
         if self.args.action == Action.TYPE:

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Union
 
 import configargparse
 
-from .models import Action, Target, Targets, CANCEL, DEFAULT
+from .models import Action, Target, Targets, CANCEL
 from .clipboarder import Clipboarder
 from .typer import Typer
 from .selector import Selector

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -123,22 +123,20 @@ class RofiRbw(object):
 
         (selected_targets, selected_action, selected_string) = self.selector.show_selection(
             entries,
+            self.args.targets,
+            self.args.action,
             self.args.prompt,
             self.args.show_help,
             self.args.selector_args
         )
         if selected_action == CANCEL():
             return
+        self.args.targets = selected_targets
+        self.args.action = selected_action
 
         selected_entry = Entry.parse_formatted_string(selected_string)
 
         credential = self.get_credentials(selected_entry.name, selected_entry.folder, selected_entry.username)
-
-        if selected_targets != DEFAULT():
-            self.args.targets = selected_targets
-
-        if selected_action != DEFAULT():
-            self.args.action = selected_action
 
         if Targets.MENU in self.args.targets:
             targets, action = self.show_target_menu(credential, self.args.show_help,)

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -27,10 +27,12 @@ class Selector:
     def show_selection(
         self,
         entries: List[str],
+        default_targets: List[Target],
+        default_action: Action,
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], DEFAULT, CANCEL], Union[Action, DEFAULT, CANCEL], str]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL], str]:
         print('Could not find a valid way to show the selection. Please check the required dependencies.')
         exit(4)
 
@@ -39,7 +41,7 @@ class Selector:
         targets: List[str],
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], CANCEL], Union[Action, DEFAULT, CANCEL]]:
+    ) -> Tuple[List[Target], Union[Action, DEFAULT, CANCEL]]:
         print('Could not find a valid way to show the selection. Please check the required dependencies.')
         exit(4)
 
@@ -56,10 +58,12 @@ class Rofi(Selector):
     def show_selection(
         self,
         entries: List[str],
+        default_targets: List[Target],
+        default_action: Action,
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], DEFAULT, CANCEL], Union[Action, DEFAULT, CANCEL], str]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL], str]:
         parameters = [
             'rofi',
             '-markup-rows',
@@ -94,7 +98,7 @@ class Rofi(Selector):
 
         if rofi.returncode == 1:
             return_action = CANCEL()
-            return_targets = CANCEL()
+            return_targets = []
         elif rofi.returncode == 10:
             return_action = Action.TYPE
             return_targets = [Targets.USERNAME, Targets.PASSWORD]
@@ -114,11 +118,11 @@ class Rofi(Selector):
             return_action = Action.COPY
             return_targets = [Targets.TOTP]
         elif rofi.returncode == 23:
-            return_action = DEFAULT
+            return_action = default_action
             return_targets = [Targets.MENU]
         else:
-            return_action = DEFAULT()
-            return_targets = DEFAULT()
+            return_action = default_action
+            return_targets = default_targets
 
         return return_targets, return_action, rofi.stdout
 
@@ -179,10 +183,12 @@ class Wofi(Selector):
     def show_selection(
         self,
         entries: List[str],
+        default_targets: List[Target],
+        default_action: Action,
         prompt: str,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], DEFAULT, CANCEL], Union[Action, DEFAULT, CANCEL],  str]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL], str]:
         parameters = [
             'wofi',
             '--dmenu',
@@ -198,9 +204,9 @@ class Wofi(Selector):
             encoding='utf-8'
         )
         if wofi.returncode == 0:
-            return DEFAULT(), DEFAULT(), wofi.stdout
+            return default_targets, default_action, wofi.stdout
         else:
-            return CANCEL(), CANCEL(), wofi.stdout
+            return [], CANCEL(), wofi.stdout
 
     def select_target(
         self,

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -39,9 +39,10 @@ class Selector:
     def select_target(
         self,
         targets: List[str],
+        default_action: Action,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[List[Target], Union[Action, DEFAULT, CANCEL]]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL]]:
         print('Could not find a valid way to show the selection. Please check the required dependencies.')
         exit(4)
 
@@ -129,9 +130,10 @@ class Rofi(Selector):
     def select_target(
         self,
         targets: List[str],
+        default_action: Action,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], CANCEL], Union[Action, DEFAULT, CANCEL]]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL]]:
         parameters = [
             'rofi',
             '-markup-rows',
@@ -158,13 +160,13 @@ class Rofi(Selector):
         )
 
         if rofi.returncode == 1:
-            return CANCEL(), CANCEL()
+            return [], CANCEL()
         elif rofi.returncode == 20:
             action = Action.TYPE
         elif rofi.returncode == 21:
             action = Action.COPY
         else:
-            action = DEFAULT()
+            action = default_action
 
         targets = [Target(entry.split(':')[0]) for entry in rofi.stdout.strip().split('\n')]
 
@@ -211,9 +213,10 @@ class Wofi(Selector):
     def select_target(
         self,
         targets: List[str],
+        default_action: Action,
         show_help_message: bool,
         additional_args: List[str]
-    ) -> Tuple[Union[List[Target], CANCEL], Union[Action, DEFAULT, CANCEL]]:
+    ) -> Tuple[List[Target], Union[Action, CANCEL]]:
         parameters = [
             'wofi',
             '--dmenu',
@@ -228,7 +231,7 @@ class Wofi(Selector):
         )
 
         if wofi.returncode == 1:
-            return CANCEL(), CANCEL()
+            return [], CANCEL()
 
-        return [Target(entry.split(':')[0]) for entry in wofi.stdout.strip().split('\n')], DEFAULT()
+        return [Target(entry.split(':')[0]) for entry in wofi.stdout.strip().split('\n')], default_action
 

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -2,7 +2,7 @@ from subprocess import run
 from typing import List, Tuple, Union
 
 from .abstractionhelper import is_wayland, is_installed
-from .models import Action, Target, Targets, CANCEL, DEFAULT
+from .models import Action, Target, Targets, CANCEL
 
 
 class Selector:

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -83,11 +83,20 @@ class Rofi(Selector):
             'Alt+m',
             *additional_args
         ]
+        keys = {
+            10: ('<b>Alt+1</b> Type username and password', [Targets.USERNAME, Targets.PASSWORD], Action.TYPE),
+            11: ('<b>Alt+2</b> Type username', [Targets.USERNAME], Action.TYPE),
+            12: ('<b>Alt+3</b> Type password', [Targets.PASSWORD], Action.TYPE),
+            21: ('<b>Alt+u</b> Copy username', [Targets.USERNAME], Action.COPY),
+            20: ('<b>Alt+p</b> Copy password', [Targets.PASSWORD], Action.COPY),
+            22: ('<b>Alt+t</b> Copy totp', [Targets.TOTP], Action.COPY),
+            23: ('<b>Alt+m</b> Show menu', [Targets.MENU], default_action)
+        }
 
         if show_help_message:
             parameters.extend([
                 '-mesg',
-                '<b>Alt+1</b>: Autotype username and password | <b>Alt+2</b> Type username | <b>Alt+3</b> Type password | <b>Alt+u</b> Copy username | <b>Alt+p</b> Copy password | <b>Alt+t</b> Copy totp'
+                ' | '.join(keys[k][0] for k in keys if not (keys[k][1] == default_targets and keys[k][2] == default_action))
             ])
 
         rofi = run(
@@ -100,27 +109,9 @@ class Rofi(Selector):
         if rofi.returncode == 1:
             return_action = CANCEL()
             return_targets = []
-        elif rofi.returncode == 10:
-            return_action = Action.TYPE
-            return_targets = [Targets.USERNAME, Targets.PASSWORD]
-        elif rofi.returncode == 11:
-            return_action = Action.TYPE
-            return_targets = [Targets.USERNAME]
-        elif rofi.returncode == 12:
-            return_action = Action.TYPE
-            return_targets = [Targets.PASSWORD]
-        elif rofi.returncode == 20:
-            return_action = Action.COPY
-            return_targets = [Targets.PASSWORD]
-        elif rofi.returncode == 21:
-            return_action = Action.COPY
-            return_targets = [Targets.USERNAME]
-        elif rofi.returncode == 22:
-            return_action = Action.COPY
-            return_targets = [Targets.TOTP]
-        elif rofi.returncode == 23:
-            return_action = default_action
-            return_targets = [Targets.MENU]
+        elif rofi.returncode in keys:
+            return_action = keys[rofi.returncode][2]
+            return_targets = keys[rofi.returncode][1]
         else:
             return_action = default_action
             return_targets = default_targets


### PR DESCRIPTION
This PR build further upon #48, hence the WIP and I'll fix this once that PR has been accepted or denied.

When calling `rbw-rofi` with an `--action` argument, the help message and alt-codes in rofi (`--mesg`) is unchanged. I think it would be neat to make these adaptive, such that the default action is not an alt-code.

In the case that the help message is not rendered, having it adaptive would be confusing (imo) and thus the list is then a fixed order: both, username, password, menu.

PS: this was my main motivation for PR #48.