### PR TITLE
Fix and improve clipboard clearing

### DIFF
--- a/src/rofi_rbw/clipboarder.py
+++ b/src/rofi_rbw/clipboarder.py
@@ -54,7 +54,11 @@ class XSelClipboarder(Clipboarder):
     def clear_clipboard_after(self, clear: int) -> None:
         if clear > 0:
             time.sleep(clear)
-            run(['xsel', '-delete'])
+            run([
+                'xsel',
+                '-d',
+                '-b'
+            ])
 
 
 class XClipClipboarder(Clipboarder):

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -202,7 +202,7 @@ class RofiRbw(object):
         elif self.args.action == Action.COPY:
             for target in self.args.targets:
                 self.clipboarder.copy_to_clipboard(cred[target])
-            if Targets.PASSWORD in self.args.targets:
+            if len(self.args.targets) == 1 and self.args.targets[0] == Targets.PASSWORD:
                 self.clipboarder.clear_clipboard_after(self.args.clear)
         elif self.args.action == Action.PRINT:
             print('\n'.join([cred[target] for target in self.args.targets]))

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -202,7 +202,7 @@ class RofiRbw(object):
         elif self.args.action == Action.COPY:
             for target in self.args.targets:
                 self.clipboarder.copy_to_clipboard(cred[target])
-            if len(self.args.targets) == 1 and self.args.targets[0] == Targets.PASSWORD:
+            if Targets.PASSWORD in self.args.targets:
                 self.clipboarder.clear_clipboard_after(self.args.clear)
         elif self.args.action == Action.PRINT:
             print('\n'.join([cred[target] for target in self.args.targets]))


### PR DESCRIPTION
Hi again, just some quick fixes for clipboard clearing

:bug: Updated `clear-after` to work when `targets` contains `PASSWORD`, not just when the only target is `PASSWORD`. This allows it to work when no target is defined and the default of `[USERNAME, PASSWORD]` is used
:bug: Fixed a syntax error and bug with clearing clipboard using `xsel`