### PR TITLE
Fixing first entry when not in a folder

### DIFF
--- a/src/rofi_rbw/rbw.py
+++ b/src/rofi_rbw/rbw.py
@@ -17,7 +17,7 @@ class Rbw:
             exit(2)
 
         return sorted(
-            [self.__parse_rbw_output(it) for it in (rbw.stdout.strip().split("\n"))],
+            [self.__parse_rbw_output(it) for it in (rbw.stdout[:-1].split("\n"))],
             key=lambda x: x.folder.lower() + x.name.lower(),
         )
 

--- a/src/rofi_rbw/rbw.py
+++ b/src/rofi_rbw/rbw.py
@@ -17,7 +17,7 @@ class Rbw:
             exit(2)
 
         return sorted(
-            [self.__parse_rbw_output(it) for it in (rbw.stdout[:-1].split("\n"))],
+            [self.__parse_rbw_output(it) for it in (rbw.stdout.strip("\n").split("\n"))],
             key=lambda x: x.folder.lower() + x.name.lower(),
         )
 


### PR DESCRIPTION
An empty folder in the beginning was removed by strip() leading to non-functional entries. 
Alternatively to this solution you might .strip("\n") or append 'if it' in the list comprehension. I tested all three possibilities, but don't know if there might be other edge cases.
Example output from `rbw list --fields=folder,name,user` that fails with the current code `\tEntryName1\tUserName1\n\tEntryName2\tUserName2\n\n`.

We can also think about altering the order since names cannot be empty in Bitwarden, but both username and folder are optional.