### PR TITLE
Fix Selector.justify

### DIFF
--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -84,7 +84,12 @@ class Selector:
 
     @staticmethod
     def justify(entry: Entry, max_width: int, show_folders: bool) -> str:
-        return " " * (max_width - len(entry.name) - ((len(entry.folder) + 1) if show_folders else 0))
+        whitespace_length = max_width - len(entry.name)
+        if show_folders:
+            whitespace_length -= len(entry.folder)
+            if entry.folder:
+                whitespace_length -= 1
+        return " " * whitespace_length
 
 
 class Rofi(Selector):


### PR DESCRIPTION
Hi,

In the current version, when `show_folders` is True, `len(entry.folder) + 1` is substracted. This 1 is here for the `/`, but when some entries are in the root folder, this `/` is taken in account but not shown, and therefore the padding is off by one, eg:

```
<b>example.com</b>        example-user
folder/<b>example.net</b>  other-user
```

This PR therefore substract 1 only when there is a folder, and a `/`.