### PR TITLE
Remove empty entries from the list

### DIFF
--- a/src/rofi_rbw/rbw.py
+++ b/src/rofi_rbw/rbw.py
@@ -17,7 +17,7 @@ class Rbw:
             exit(2)
 
         return sorted(
-            [self.__parse_rbw_output(it) for it in (rbw.stdout.strip("\n").split("\n"))],
+            [self.__parse_rbw_output(it) for it in rbw.stdout.strip("\n").split("\n") if it],
             key=lambda x: x.folder.lower() + x.name.lower(),
         )
 


### PR DESCRIPTION
For unknown reasons, my list contains an empty element which results in the following stack trace

```
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/rofi_rbw/rbw.py", line 28, in __parse_rbw_output
    return Entry(fields[1], fields[0], fields[2] if len(fields) > 2 else "")
                 ~~~~~~^^^
IndexError: list index out of range

For some unknown reason, my list contains an empty element, resulting in the following stack trace

Traceback (most recent call last):
  File "/usr/bin/rofi-rbw", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/rofi_rbw/__main__.py", line 5, in main
    RofiRbw().main()
  File "/usr/lib/python3.11/site-packages/rofi_rbw/rofi_rbw.py", line 157, in main
    self.rbw.list_entries(),
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/rofi_rbw/rbw.py", line 20, in list_entries
    [self.__parse_rbw_output(it) for it in (rbw.stdout.strip().split("\n"))],
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/rofi_rbw/rbw.py", line 20, in <listcomp>
    [self.__parse_rbw_output(it) for it in (rbw.stdout.strip().split("\n"))],
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/rofi_rbw/rbw.py", line 30, in __parse_rbw_output
    raise Exception("Entry is incorrectly formatted and cannot be parsed")
Exception: Entry is incorrectly formatted and cannot be parsed
```

This PR skips these entries.