### PR TITLE
Fix auto selector when using Wayland

### DIFF
--- a/src/rofi_rbw/abstractionhelper.py
+++ b/src/rofi_rbw/abstractionhelper.py
@@ -5,6 +5,8 @@ import shutil
 def is_installed(executable: str) -> bool:
     return shutil.which(executable) is not None
 
+def is_x_window_system() -> bool:
+    return os.environ.get("DISPLAY", False)
 
 def is_wayland() -> bool:
     return os.environ.get("WAYLAND_DISPLAY", False)

--- a/src/rofi_rbw/selector.py
+++ b/src/rofi_rbw/selector.py
@@ -2,7 +2,7 @@ import re
 from subprocess import run
 from typing import Dict, List, Tuple, Union
 
-from .abstractionhelper import is_installed, is_wayland
+from .abstractionhelper import is_installed, is_wayland, is_x_window_system
 from .credentials import Credentials
 from .entry import Entry
 from .models import Action, Keybinding, Target, Targets
@@ -102,7 +102,7 @@ class Selector:
 class Rofi(Selector):
     @staticmethod
     def supported() -> bool:
-        return is_installed("rofi")
+        return is_x_window_system() and is_installed("rofi")
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
Prior to this change, rofi-rbw only checked in wayland if rofi is installed and tried immediately to use it, even when not in X. Thus auto-choosing the selector in wayland does not work.