### PR TITLE
Let wl-copy treat passwords as sensitive

### DIFF
--- a/src/rofi_rbw/clipboarder/wlclip.py
+++ b/src/rofi_rbw/clipboarder/wlclip.py
@@ -15,7 +15,7 @@ class WlClipboarder(Clipboarder):
         return "wl-copy"
 
     def copy_to_clipboard(self, characters: str) -> None:
-        run(["wl-copy"], input=characters, encoding="utf-8")
+        run(["wl-copy", "--type", "x-kde-passwordManagerHint"], input=characters, encoding="utf-8")
 
     def clear_clipboard_after(self, clear: int) -> None:
         if clear > 0:


### PR DESCRIPTION
wl-copy will (sometime) soon be able to differentiate when sensitive data is being copied, so that clipboard managers (like cliphist) can ignore this data downstream.

Keepass has been flagging passwords as sensitive by setting a mime type of "x-kde-passwordManagerHint" and this is how wl-clipboard will implement it.

This PR is a only a draft because the feature has not yet been merged: https://github.com/bugaevc/wl-clipboard/pull/204 https://github.com/bugaevc/wl-clipboard/issues/177

I am currently using those changes and it works well, the copied entries from rofi-rbw are not stored by my clipboard manager.

EDIT: if theres interest and the wl-clipboard PR gets merged, I can open the PR properly
