### PR TITLE
fix xdotool.py : avoid tab key discarded

### DIFF
--- a/src/rofi_rbw/typer/xdotool.py
+++ b/src/rofi_rbw/typer/xdotool.py
@@ -37,7 +37,7 @@ class XDoToolTyper(Typer):
         if key == Key.ENTER:
             key_name = "enter"
         elif key == Key.TAB:
-            key_name = "tab"
+            key_name = "Tab"
         else:
             raise Exception("Unknown key")
 


### PR DESCRIPTION
The "tab" key is not taken into account in xdotool but "Tab" is. I do not have test it on multiple version of xdotools