### PR TITLE
Add option to send desktop notification when copying totp to the clipboard

### DIFF
--- a/src/rofi_rbw/argument_parsing.py
+++ b/src/rofi_rbw/argument_parsing.py
@@ -76,6 +76,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.set_defaults(show_folders=True)
     parser.add_argument("--no-cache", dest="use_cache", action="store_false", help="Don't save history in cache")
     parser.set_defaults(use_cache=True)
+    parser.add_argument("--use-notify-send", dest="use_notify_send", action="store_true", help="Send desktop notification after copying TOTP")
+    parser.set_defaults(use_notify_send=False)
     parser.add_argument(
         "--keybindings",
         dest="keybindings",

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -1,3 +1,4 @@
+from subprocess import run
 import time
 from typing import List, Tuple, Union
 
@@ -121,3 +122,5 @@ class RofiRbw(object):
                 self.typer.type_characters(cred[target], self.args.key_delay, self.active_window)
         if Targets.PASSWORD in targets and cred.totp != "":
             self.clipboarder.copy_to_clipboard(cred.totp)
+            if self.args.use_notify_send:
+                run(["notify-send", "-u", "normal", "-t", "3000", "rofi-rbw", "totp copied to clipboard"], check=True)


### PR DESCRIPTION
This change adds --use-notify-send so that a desktop notification is sent when a totp code is copied to the clipboard. The purpose of this is there are times when there is a delay between typing the password and copying the totp and if one pastes too quickly, something other than the totp will be pasted.