### PR TITLE
Add documentation for #101

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can configure `rofi-rbw` either with cli arguments or with a config file cal
 | `--selector`         |              | `rofi`, `wofi`                                                | Show the selection dialog with this application. Chosen automatically by default.                                                                                                                                                                                           |
 | `--clipboarder`      |              | `xsel`, `xclip`, `wl-copy`                                    | Access the clipboard with this application. Chosen automatically by default.                                                                                                                                                                                                |
 | `--typer`            |              | `xdotool`, `wtype`, `ydotool`, `dotool`                       | Type the characters using this application. Chosen automatically by default.                                                                                                                                                                                                |
+| `--use-notify-send`  |              |                                                               | Send desktop notification after copying TOTP.                                                                                                                                                                                                                               |
 ## Autotyping
 By default, `Alt+1` will type username and password, separated with a `tab` character. However, you can change this behavior by defining your own keybinding (if your selector supports this). For example, `Alt+1:type:username:enter:delay:password:enter` will type the username, `enter`, wait for a second and then type the password and `enter` again.
 
@@ -61,3 +62,4 @@ You also need:
 - `rofi` or `wofi`
 - Something to programmatically type characters into other applications. Depending on your display server, it's `xdotool`, `wtype`, `ydotool` or `dotool`.
 - Something to copy text to the clipboard. Again, depending on the display server, you want `xclip`, `xsel` or `wl-copy`.
+- Optionally `libnotify` to provide `notify-send` needed for `--use-notify-send`

--- a/docs/rofi-rbw.1
+++ b/docs/rofi-rbw.1
@@ -18,6 +18,7 @@ client rbw
 [\f[B]\-\-no\-help\f[R]] [\f[B]\-\-no\-folder\f[R]]
 [\f[B]\-\-keybindings\f[R] \f[I]KEYBINDINGS\f[R]]
 [\f[B]\-\-menu\-keybindings\f[R] \f[I]MENU_KEYBINDINGS\f[R]]
+[\f[B]\-\-use\-notify\-send\f[R]]
 .SH DESCRIPTION
 Type, copy or print your credentials from Bitwarden using rofi.
 .SH OPTIONS
@@ -110,6 +111,10 @@ Possible values: xdotool, wtype, ydotool, dotool
 .RS
 .PP
 Choose the application to type with manually.
+.RE
+.TP
+\-\-use\-notify\-send
+Send desktop notification after copying TOTP.
 .RE
 .SH DEFAULT KEYBINDINGS
 \f[I]enter\f[R] to use the default action

--- a/docs/rofi-rbw.1.md
+++ b/docs/rofi-rbw.1.md
@@ -16,6 +16,7 @@
          \[**\--clear-after** *NUMBER*] \[**\--typing-key-delay** *NUMBER*]
          \[**\--no-help**] \[**\--no-folder**]
          \[**\--keybindings** *KEYBINDINGS*] \[**\--menu-keybindings** *MENU_KEYBINDINGS*]
+         \[**\--use-notify-send**]
 
 # DESCRIPTION
 
@@ -102,6 +103,10 @@ Type, copy or print your credentials from Bitwarden using rofi.
 : Possible values: xdotool, wtype, ydotool, dotool
 
       Choose the application to type with manually.
+
+\--use-notify-send
+
+: Send desktop notification after copying TOTP.
 
 # DEFAULT KEYBINDINGS
 


### PR DESCRIPTION
This adds the `--use-notify-send` flag added in #101 to the doc, manpage and readme and documents the optional dependency to libnotify in the readme aswell.