### PR TITLE
fix hatch build configuration for `python -m build` and others

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ rofi-rbw = "rofi_rbw.__main__:main"
 requires = ["hatchling>=1.18"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.sdist]
 packages = ["src/rofi_rbw"]
 include = ["docs/rofi-rbw.1"]
 


### PR DESCRIPTION
Previous configuration worked with the `hatch` frontend but produced an empty package with other tools like `python -m build` or `uv build`.

Closes #112