### PR TITLE
fix: name parsing with slashes

### DIFF
--- a/src/rofi_rbw/selector/bemenu.py
+++ b/src/rofi_rbw/selector/bemenu.py
@@ -51,7 +51,7 @@ class Bemenu(Selector):
         ]
 
     def __parse_formatted_string(self, formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
+        match = re.compile("(?:(?P<folder>.+?)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
 
         return Entry(match.group("name").strip(), match.group("folder"), match.group("username").strip())
 

--- a/src/rofi_rbw/selector/fuzzel.py
+++ b/src/rofi_rbw/selector/fuzzel.py
@@ -50,7 +50,7 @@ class Fuzzel(Selector):
         ]
 
     def __parse_formatted_string(self, formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
+        match = re.compile("(?:(?P<folder>.+?)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
 
         return Entry(match.group("name").strip(), match.group("folder"), match.group("username").strip())
 

--- a/src/rofi_rbw/selector/rofi.py
+++ b/src/rofi_rbw/selector/rofi.py
@@ -71,7 +71,7 @@ class Rofi(Selector):
         ]
 
     def __parse_formatted_string(self, formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?<b>(?P<name>.*?) *</b>(?P<username>.*)").search(formatted_string)
+        match = re.compile("(?:(?P<folder>.+?)/)?<b>(?P<name>.*?) *</b>(?P<username>.*)").search(formatted_string)
 
         return Entry(match.group("name"), match.group("folder"), match.group("username").strip())
 

--- a/src/rofi_rbw/selector/wofi.py
+++ b/src/rofi_rbw/selector/wofi.py
@@ -51,7 +51,7 @@ class Wofi(Selector):
         ]
 
     def __parse_formatted_string(self, formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
+        match = re.compile("(?:(?P<folder>.+?)/)?(?P<name>.*?) *  (?P<username>.*)").search(formatted_string)
 
         return Entry(match.group("name").strip(), match.group("folder"), match.group("username").strip())
 


### PR DESCRIPTION
Rofi-rbw fails to retrieve entries with slashes after parsing.

Example:
folder: `Web`, entry name: `github.com/main-account`

rofi-rbw matches `Web/github.com` as folder and `main-account` as entry name. This results in `Could not parse the output: Expecting value` error message because no entry with the name of `main-account` is found.

This fails due to the greedy `.+` regex operator in  `__parse_formatted_string` method. My proposed solution is to make the `.+` matching non-greedy by appending the `?` operator, thus the result of parsing is:

folder: `Web`, entry name: `github.com/main-account`