### PR TITLE
feat: add capability to create new entries with alt+n uses clipboard for url that can be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Based on the alternative [Bitwarden](https://bitwarden.com/) CLI [rbw](https://g
 - Autotype username and password (with a `tab` character in between) with `Alt+1` (and copy TOTP to clipboard)
 - Configure autotyping either as a keybinding or by having a `_autotype` field in your credential
 - Copy username, password or TOTP to the clipboard (`Alt+u`, `Alt+p` and `Alt+t`, respectively)
+- Add new entries with `Alt+n` (automatically detects URLs from clipboard and generates secure passwords)
 - Show an autotype menu with all fields
 
 ## Usage

--- a/docs/rofi-rbw.1.md
+++ b/docs/rofi-rbw.1.md
@@ -9,7 +9,7 @@
 
 # SYNOPSIS
 
-| **rofi-rbw** \[**-h**] \[**\--version**] \[**\--action** {*type*,*copy*,*print*}]
+| **rofi-rbw** \[**-h**] \[**\--version**] \[**\--action** {*type*,*copy*,*print*,*add*}]
          \[**\--target** {*username*,*password*,*totp*,*OTHER*}]
          \[**\--prompt** *PROMPT*] \[**\--selector-args** *SELECTOR_ARGS*]
          \[**\--clipboarder** *CLIPBOARDER*] \[**\--typer** *TYPER*] \[**\--selector** *SELECTOR*]
@@ -34,9 +34,9 @@ Type, copy or print your credentials from Bitwarden using rofi.
 
 \--action, -a
 
-: Possible values: type, copy, print
+: Possible values: type, copy, print, add
 
-      Choose what to do with the selected characters: Directly type them with the "Typer", copy them to the clipboard using the "Clipboarder", or "print" them on stdout
+      Choose what to do with the selected characters: Directly type them with the "Typer", copy them to the clipboard using the "Clipboarder", "print" them on stdout, or "add" a new entry to the database
 
 \--target, -t
 
@@ -121,6 +121,8 @@ Type, copy or print your credentials from Bitwarden using rofi.
 *alt+m* to show a menu of the entry's components
 
 *alt+s* to sync the contents of the vault
+
+*alt+n* to add a new entry (detects URLs from clipboard and generates secure passwords)
 
 *alt+1* to autotype username and password, separated with a `tab` character
 

--- a/src/rofi_rbw/abstractionhelper.py
+++ b/src/rofi_rbw/abstractionhelper.py
@@ -8,3 +8,18 @@ def is_installed(executable: str) -> bool:
 
 def is_wayland() -> bool:
     return os.environ.get("WAYLAND_DISPLAY", False) is not None
+
+def extract_domain_from_url(url: str) -> str:
+    """Extract domain from URL, removing protocol, www, and path/query parameters."""
+    import re
+    
+    # Remove protocol
+    url = re.sub(r'^https?://', '', url)
+    
+    # Remove www prefix
+    url = re.sub(r'^www\.', '', url)
+    
+    # Extract domain (everything before first slash or query parameter)
+    domain = url.split('/')[0].split('?')[0].split('#')[0]
+    
+    return domain

--- a/src/rofi_rbw/argument_parsing.py
+++ b/src/rofi_rbw/argument_parsing.py
@@ -101,6 +101,7 @@ def parse_arguments() -> argparse.Namespace:
                 "Alt+t:copy:totp",
                 "Alt+m::menu",
                 "Alt+s:sync",
+                "Alt+n:add",
             ]
         ),
         help="Define keyboard shortcuts in the format <shortcut>:<action>:<target>, separated with a comma",

--- a/src/rofi_rbw/clipboarder/clipboarder.py
+++ b/src/rofi_rbw/clipboarder/clipboarder.py
@@ -34,6 +34,10 @@ class Clipboarder(ABC):
     def clear_clipboard_after(self, clear: int) -> None:
         pass
 
+    @abstractmethod
+    def read_from_clipboard(self) -> str:
+        pass
+
 
 class NoClipboarderFoundException(Exception):
     def __str__(self) -> str:

--- a/src/rofi_rbw/clipboarder/noop.py
+++ b/src/rofi_rbw/clipboarder/noop.py
@@ -15,3 +15,6 @@ class NoopClipboarder(Clipboarder):
 
     def clear_clipboard_after(self, clear: int) -> None:
         raise NoClipboarderFoundException()
+
+    def read_from_clipboard(self) -> str:
+        raise NoClipboarderFoundException()

--- a/src/rofi_rbw/clipboarder/wlclip.py
+++ b/src/rofi_rbw/clipboarder/wlclip.py
@@ -29,5 +29,8 @@ class WlClipboarder(Clipboarder):
                 run(["wl-copy", "--clear"])
                 self.__last_copied_characters = None
 
+    def read_from_clipboard(self) -> str:
+        return self.__fetch_clipboard_content()
+
     def __fetch_clipboard_content(self) -> str:
         return run(["wl-paste"], capture_output=True, encoding="utf-8").stdout

--- a/src/rofi_rbw/clipboarder/xclip.py
+++ b/src/rofi_rbw/clipboarder/xclip.py
@@ -30,5 +30,8 @@ class XClipClipboarder(Clipboarder):
                 self.copy_to_clipboard("")
                 self.__last_copied_characters = None
 
+    def read_from_clipboard(self) -> str:
+        return self.__fetch_clipboard_content()
+
     def __fetch_clipboard_content(self) -> str:
         return run(["xclip", "-o", "-selection", "clipboard"], capture_output=True, encoding="utf-8").stdout

--- a/src/rofi_rbw/clipboarder/xsel.py
+++ b/src/rofi_rbw/clipboarder/xsel.py
@@ -30,6 +30,9 @@ class XSelClipboarder(Clipboarder):
                 run(["xsel", "--clear", "--clipboard"])
                 self.__last_copied_characters = None
 
+    def read_from_clipboard(self) -> str:
+        return self.__fetch_clipboard_content()
+
     def __fetch_clipboard_content(self) -> str:
         return run(
             [

--- a/src/rofi_rbw/models/action.py
+++ b/src/rofi_rbw/models/action.py
@@ -7,3 +7,4 @@ class Action(Enum):
     PRINT = "print"
     SYNC = "sync"
     CANCEL = "cancel"
+    ADD = "add"

--- a/src/rofi_rbw/rbw.py
+++ b/src/rofi_rbw/rbw.py
@@ -90,3 +90,35 @@ class Rbw:
 
     def sync(self):
         run(["rbw", "sync"])
+
+    def generate_password(self, length: int = 16) -> str:
+        """Generate a new password using rbw generate command."""
+        command = ["rbw", "generate", str(length)]
+        result = run(command, capture_output=True, encoding="utf-8")
+        
+        if result.returncode != 0:
+            raise Exception(f"Failed to generate password: {result.stderr}")
+        
+        return result.stdout.strip()
+
+    def add_entry(self, name: str, username: str, uri: Optional[str] = None, folder: Optional[str] = None, password_length: int = 16) -> str:
+        """Add a new entry to the password database and return the generated password."""
+        command = ["rbw", "generate", str(password_length), name]
+        
+        if username:
+            command.append(username)
+        
+        if uri:
+            command.extend(["--uri", uri])
+        
+        if folder:
+            command.extend(["--folder", folder])
+        
+        # Run the command to create entry with generated password
+        result = run(command, capture_output=True, encoding="utf-8")
+        
+        if result.returncode != 0:
+            raise Exception(f"Failed to add entry: {result.stderr}")
+        
+        # The generated password is returned in stdout
+        return result.stdout.strip()

--- a/src/rofi_rbw/selector/bemenu.py
+++ b/src/rofi_rbw/selector/bemenu.py
@@ -75,3 +75,19 @@ class Bemenu(Selector):
             return None, Action.CANCEL
 
         return self._extract_targets(bemenu.stdout), None
+
+    def show_input_dialog(self, prompt: str, default_value: str = "") -> str | None:
+        """Show an input dialog using bemenu."""
+        from subprocess import run
+        
+        bemenu = run(
+            ["bemenu", "-p", prompt],
+            input=default_value,
+            capture_output=True,
+            encoding="utf-8"
+        )
+        
+        if bemenu.returncode != 0:
+            return None  # User cancelled
+        
+        return bemenu.stdout.strip()

--- a/src/rofi_rbw/selector/fuzzel.py
+++ b/src/rofi_rbw/selector/fuzzel.py
@@ -74,3 +74,21 @@ class Fuzzel(Selector):
             return None, Action.CANCEL
 
         return self._extract_targets(fuzzel.stdout), None
+
+    def show_input_dialog(self, prompt: str, default_value: str = "") -> str | None:
+        """Show an input dialog using fuzzel."""
+        from subprocess import run
+        
+        # Fuzzel doesn't have a direct dmenu mode, so we'll use a simple approach
+        # by creating a temporary input with the default value
+        fuzzel = run(
+            ["fuzzel", "--dmenu", "--prompt", prompt],
+            input=default_value,
+            capture_output=True,
+            encoding="utf-8"
+        )
+        
+        if fuzzel.returncode != 0:
+            return None  # User cancelled
+        
+        return fuzzel.stdout.strip()

--- a/src/rofi_rbw/selector/rofi.py
+++ b/src/rofi_rbw/selector/rofi.py
@@ -139,3 +139,19 @@ class Rofi(Selector):
             return f"{keybinding.action.value.title()} {', '.join([target.raw for target in keybinding.targets])}"
         else:
             return keybinding.action.value.title()
+
+    def show_input_dialog(self, prompt: str, default_value: str = "") -> str | None:
+        """Show an input dialog using rofi."""
+        from subprocess import run
+        
+        rofi = run(
+            ["rofi", "-dmenu", "-p", prompt],
+            input=default_value,
+            capture_output=True,
+            encoding="utf-8"
+        )
+        
+        if rofi.returncode != 0:
+            return None  # User cancelled
+        
+        return rofi.stdout.strip()

--- a/src/rofi_rbw/selector/wofi.py
+++ b/src/rofi_rbw/selector/wofi.py
@@ -75,3 +75,19 @@ class Wofi(Selector):
             return None, Action.CANCEL
 
         return self._extract_targets(wofi.stdout), None
+
+    def show_input_dialog(self, prompt: str, default_value: str = "") -> str | None:
+        """Show an input dialog using wofi."""
+        from subprocess import run
+        
+        wofi = run(
+            ["wofi", "--dmenu", "--prompt", prompt],
+            input=default_value,
+            capture_output=True,
+            encoding="utf-8"
+        )
+        
+        if wofi.returncode != 0:
+            return None  # User cancelled
+        
+        return wofi.stdout.strip()


### PR DESCRIPTION
Hey there and thanks for this great rofi script.

I'm just in the course of migrating from gnu pass to vaultwarden and really am liking things so far.
This rofi script kind of is what I had with pass, but it is lacking an add new entry feature.
I'm not super fluent with python so disclaimer: I've vibe coded this feature. It seems to be doing what I want so I think this could be something that others like as well.

usage:

Copy a url (or not), bring up rofi-rbw and hit `alt+n` the url will be prefilled (you can override this value), you can then provide a username. After that a password is generated and added to the clipboard ready to paste.