### PR TITLE
feat: Add a type command delay option

### DIFF
--- a/src/rofi_rbw/argument_parsing.py
+++ b/src/rofi_rbw/argument_parsing.py
@@ -121,6 +121,14 @@ def parse_arguments() -> argparse.Namespace:
         default=0,
         help="Set the delay between key presses when typing.",
     )
+    parser.add_argument(
+        "--typing-start-delay",
+        dest="start_delay",
+        action="store",
+        type=float,
+        default=0,
+        help="Set the typing start delay.",
+    )
 
     parsed_args = parser.parse_args()
 

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -121,7 +121,7 @@ class RofiRbw(object):
             elif target == TypeTargets.TAB:
                 self.typer.press_key(Key.TAB)
             else:
-                self.typer.type_characters(detailed_entry[target], self.args.key_delay, self.active_window)
+                self.typer.type_characters(detailed_entry[target], self.args.start_delay, self.args.key_delay, self.active_window)
         if Targets.PASSWORD in targets and isinstance(detailed_entry, Credentials) and detailed_entry.totp != "":
             self.clipboarder.copy_to_clipboard(detailed_entry.totp)
             if self.args.use_notify_send:

--- a/src/rofi_rbw/typer/dotool.py
+++ b/src/rofi_rbw/typer/dotool.py
@@ -1,4 +1,5 @@
 from subprocess import run
+from time import sleep
 
 from ..abstractionhelper import is_installed
 from .typer import Key, Typer
@@ -16,7 +17,8 @@ class DotoolTyper(Typer):
     def get_active_window(self) -> str:
         return "not possible with dotool"
 
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
+        sleep(start_delay)
         run(["dotool"], input=f"typedelay {key_delay}\ntype {characters}", encoding="utf-8")
 
     def press_key(self, key: Key) -> None:

--- a/src/rofi_rbw/typer/noop.py
+++ b/src/rofi_rbw/typer/noop.py
@@ -13,7 +13,7 @@ class NoopTyper(Typer):
     def get_active_window(self) -> str:
         raise NoTyperFoundException()
 
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
         raise NoTyperFoundException()
 
     def press_key(self, key: Key) -> None:

--- a/src/rofi_rbw/typer/typer.py
+++ b/src/rofi_rbw/typer/typer.py
@@ -33,7 +33,7 @@ class Typer(ABC):
         pass
 
     @abstractmethod
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
         pass
 
     @abstractmethod

--- a/src/rofi_rbw/typer/wtype.py
+++ b/src/rofi_rbw/typer/wtype.py
@@ -1,4 +1,5 @@
 from subprocess import run
+from time import sleep
 
 from ..abstractionhelper import is_installed, is_wayland
 from .typer import Key, Typer
@@ -16,7 +17,8 @@ class WTypeTyper(Typer):
     def get_active_window(self) -> str:
         return "not possible with wtype"
 
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
+        sleep(start_delay)
         args = ["wtype"]
 
         if key_delay > 0:

--- a/src/rofi_rbw/typer/xdotool.py
+++ b/src/rofi_rbw/typer/xdotool.py
@@ -1,4 +1,5 @@
 from subprocess import run
+from time import sleep
 
 from ..abstractionhelper import is_installed, is_wayland
 from .typer import Key, Typer
@@ -16,7 +17,8 @@ class XDoToolTyper(Typer):
     def get_active_window(self) -> str:
         return run(args=["xdotool", "getactivewindow"], capture_output=True, encoding="utf-8").stdout[:-1]
 
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
+        sleep(start_delay)
         run(
             [
                 "xdotool",

--- a/src/rofi_rbw/typer/ydotool.py
+++ b/src/rofi_rbw/typer/ydotool.py
@@ -1,4 +1,5 @@
 from subprocess import run
+from time import sleep
 
 from ..abstractionhelper import is_installed, is_wayland
 from .typer import Key, Typer
@@ -16,7 +17,8 @@ class YDotoolTyper(Typer):
     def get_active_window(self) -> str:
         return "not possible with ydotool"
 
-    def type_characters(self, characters: str, key_delay: int, active_window: str) -> None:
+    def type_characters(self, characters: str, start_delay: float, key_delay: int, active_window: str) -> None:
+        sleep(start_delay)
         run(["ydotool", "type", "--key-delay", str(key_delay), characters])
 
     def press_key(self, key: Key) -> None:


### PR DESCRIPTION
This adds an argument to add a delay (sleep) before executing the typer command.

Without this i had some issues on hyprland where it sometimes cut off text.
There is a key_delay option but this adds time between keystrokes and this was not very helpful for long strings.