### PR TITLE
Fix typing passwords starting with dashes

### DIFF
--- a/src/rofi_rbw/typer/wtype.py
+++ b/src/rofi_rbw/typer/wtype.py
@@ -24,6 +24,7 @@ class WTypeTyper(Typer):
         if key_delay > 0:
             args = args + ["-d", str(key_delay)]
 
+        args.append("--")
         args.append(characters)
         run(args)
 


### PR DESCRIPTION
Hi,

For one of my passwords, selecting it on rofi-rbw would not do anything.
It turns out that the auto-generated thing did start with a dash, and `wtype -something` fail: we need `wtype -- -something`