### PR TITLE
Fix wayland detection always returning True

### DIFF
--- a/src/rofi_rbw/abstractionhelper.py
+++ b/src/rofi_rbw/abstractionhelper.py
@@ -7,4 +7,4 @@ def is_installed(executable: str) -> bool:
 
 
 def is_wayland() -> bool:
-    return os.environ.get("WAYLAND_DISPLAY", False) is not None
+    return os.environ.get("WAYLAND_DISPLAY") is not None


### PR DESCRIPTION
After updating to 1.6.0, rofi-rbw did not start anymore for me with an error indicating a missing typer, even though xdotool was still installed.

The problem turned out to be the `is_wayland()` function always returning true, because of the updated checking of the environment variable to not be None, while at the same time providing a default value. This caused xdotool to no longer be considered.