### PR TITLE
Support forward-slashes in key names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ include = ["docs/rofi-rbw.1"]
 dev = [
     "ruff>=0.14.13",
     "pytest>=8.0",
+    "hypothesis>=6.0",
 ]
 
 [tool.ruff]

--- a/src/rofi_rbw/selector/rofi.py
+++ b/src/rofi_rbw/selector/rofi.py
@@ -1,4 +1,3 @@
-import re
 from subprocess import run
 
 from ..abstractionhelper import is_installed
@@ -45,7 +44,7 @@ class Rofi(Selector):
 
         rofi = run(
             parameters,
-            input="\n".join(self.__format_entries(entries, show_folders)),
+            input="\n".join(self._format_entries(entries, show_folders)),
             capture_output=True,
             encoding="utf-8",
         )
@@ -60,25 +59,14 @@ class Rofi(Selector):
             return_action = None
             return_targets = None
 
-        return return_targets, return_action, self.__find_entry(entries, rofi.stdout)
+        return return_targets, return_action, self._find_entry(entries, rofi.stdout)
 
-    def __format_entries(self, entries: list[Entry], show_folders: bool) -> list[str]:
+    def _format_entries(self, entries: list[Entry], show_folders: bool) -> list[str]:
         max_width = self._calculate_max_width(entries, show_folders)
         return [
             f"{self._format_folder(it, show_folders)}<b>{it.name}</b>{self.justify(it, max_width, show_folders)}  {it.username}"
             for it in entries
         ]
-
-    def __find_entry(self, entries: list[Entry], formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?<b>(?P<name>.*?)</b> {2,}(?P<username>.*)").search(formatted_string)
-
-        return next(
-            entry
-            for entry in entries
-            if entry.name == match.group("name")
-            and (match.group("folder") is None or entry.folder == match.group("folder"))
-            and (match.group("username") is None or entry.username == match.group("username").strip())
-        )
 
     def select_target(
         self,

--- a/src/rofi_rbw/selector/selector.py
+++ b/src/rofi_rbw/selector/selector.py
@@ -71,17 +71,14 @@ class Selector(ABC):
             for it in entries
         ]
 
-    @staticmethod
-    def _find_entry(entries: list[Entry], formatted_string: str) -> Entry:
-        match = re.compile("(?:(?P<folder>.+)/)?(?P<name>.*?) {2,}(?P<username>.*)").search(formatted_string)
-
-        return next(
-            entry
-            for entry in entries
-            if entry.name == match.group("name")
-            and (match.group("folder") is None or entry.folder == match.group("folder"))
-            and (match.group("username") is None or entry.username == match.group("username").strip())
-        )
+    def _find_entry(self, entries: list[Entry], selected: str) -> Entry:
+        """Reverse _format_entries by matching `selected` against output from both show_folders modes."""
+        selected = selected.strip()
+        for show_folders in (True, False):
+            lookup = {s.strip(): e for s, e in zip(self._format_entries(entries, show_folders), entries)}
+            if selected in lookup:
+                return lookup[selected]
+        raise KeyError(selected)
 
     def _format_targets_from_entry(self, entry: DetailedEntry) -> list[str]:
         if isinstance(entry, Credentials):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,27 @@
+import string
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from rofi_rbw.models.entry import Entry
+from rofi_rbw.models.EntryType import EntryType
+from rofi_rbw.selector.bemenu import Bemenu
+
+# Any concrete Selector works; we only need an instance to call inherited methods.
+_selector = Bemenu()
+_text = st.text(alphabet=string.ascii_letters + string.digits + "/-_.", min_size=1, max_size=20)
+
+
+@given(
+    name=_text,
+    folder=st.one_of(st.just(""), _text),
+    username=st.one_of(st.just(""), _text),
+    entry_type=st.sampled_from(EntryType),
+    show_folders=st.booleans(),
+)
+def test_format_find_round_trip(name, folder, username, entry_type, show_folders):
+    """An entry must round-trip through _format_entries → _find_entry, even after the selector strips trailing whitespace."""
+    entry = Entry(name=name, folder=folder, username=username, type=entry_type)
+    formatted = _selector._format_entries([entry], show_folders=show_folders)
+    # Selectors (e.g. fuzzel) strip trailing whitespace from echoed selections.
+    assert _selector._find_entry([entry], formatted[0].rstrip()) == entry

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz", hash = "sha256:31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4", size = 466444, upload-time = "2026-04-27T20:18:37.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl", hash = "sha256:e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8", size = 532145, upload-time = "2026-04-27T20:18:35.043Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -96,6 +109,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -105,6 +119,7 @@ requires-dist = [{ name = "configargparse", specifier = ">1.3,<2.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.14.13" },
 ]
@@ -132,6 +147,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See #129 

The regex used `/` to split folder from name, which broke entries like `service/my-api-key-name` that have `/` in the name but no folder. Split on 2+ spaces instead, matching the format from _format_entries.