### PR TITLE
Update dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Note that it needs `configargparse` to work.
 You also need:
 - Python 3.9 or higher
 - `rofi`, `wofi`, `fuzzel` or `bemenu`
+- `rbw` 1.14 or higher
 - Something to programmatically type characters into other applications. Depending on your display server, it's `xdotool`, `wtype`, `ydotool` or `dotool`.
 - Something to copy text to the clipboard. Again, depending on the display server, you want `xclip`, `xsel` or `wl-copy`.
 - Optionally `libnotify` to provide `notify-send` needed for `--use-notify-send`


### PR DESCRIPTION
Added the requirement for 'rbw' version 1.14 or higher.

The `--raw` flag for `rbw list` was added in 1.14. See: https://github.com/doy/rbw/commit/3eca104ec7488838ad2ff149096057fc5d1a2b16