### PR TITLE
Fix clipboard clear check: wl-paste appends trailing newline

### DIFF
--- a/src/rofi_rbw/clipboarder/wlclip.py
+++ b/src/rofi_rbw/clipboarder/wlclip.py
@@ -30,4 +30,4 @@ class WlClipboarder(Clipboarder):
                 self.__last_copied_characters = None
 
     def __fetch_clipboard_content(self) -> str:
-        return run(["wl-paste"], capture_output=True, encoding="utf-8").stdout
+        return run(["wl-paste", "-n"], capture_output=True, encoding="utf-8").stdout


### PR DESCRIPTION
## Problem
`clear-after` never clears the clipboard, regardless of the configured value.

## Root cause
`WlClipboarder.__fetch_clipboard_content()` calls plain `wl-paste`, which appends a trailing newline to its output by default. The comparison in `clear_clipboard_after()` checks this fetched content against the originally copied string (which has no trailing newline), so the condition is always false and `wl-copy --clear` is never called.

## Fix
Pass `-n` (`--no-newline`) to `wl-paste` so the fetched content matches what was actually copied.

## Testing
Verified manually: copied a string via `WlClipboarder`, called `clear_clipboard_after(2)`, confirmed the clipboard is empty afterwards (previously it stayed populated indefinitely).

## Environment
- rofi-rbw main
- rbw 1.15.0
- wl-clipboard 2.3.0
- Arch Linux + sway