### PR TITLE
Fix relative import for Notifier

### DIFF
--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -1,7 +1,5 @@
 import time
 
-from .notifier import Notifier
-
 from .argument_parsing import parse_arguments
 from .cache import Cache
 from .clipboarder.clipboarder import Clipboarder
@@ -9,6 +7,7 @@ from .models.action import Action
 from .models.credentials import Credentials
 from .models.detailed_entry import DetailedEntry
 from .models.targets import Target, Targets, TypeTargets
+from .notifier import Notifier
 from .rbw import Rbw
 from .selector.selector import Selector
 from .typer.typer import Key, Typer

--- a/src/rofi_rbw/rofi_rbw.py
+++ b/src/rofi_rbw/rofi_rbw.py
@@ -1,6 +1,6 @@
 import time
 
-from notifier import Notifier
+from .notifier import Notifier
 
 from .argument_parsing import parse_arguments
 from .cache import Cache


### PR DESCRIPTION
## Problem
Running rofi-rbw from a source checkout (e.g. `uv run rofi-rbw`) crashes immediately on startup with:
"`ModuleNotFoundError: No module named 'notifier'`"

This happens before argument parsing even runs, so every invocation fails regardless of flags used.

## Root cause
`rofi_rbw.py` imports Notifier with an absolute import:
"`from notifier import Notifier`" but `notifier.py` lives inside the `rofi_rbw` package (`src/rofi_rbw/notifier.py`), not as a top-level module. Python can't find `notifier` on sys.path, since it's only reachable as part of the package.

## Fix
Use a relative import instead:
"`from .notifier import Notifier`"

## Testing
Confirmed `uv run rofi-rbw --help` and related commands run without the "`ModuleNotFoundError after this change`".